### PR TITLE
Bump Git_jll to 2.44

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "Git"
 uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 authors = ["Dilum Aluthge", "contributors"]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 Git_jll = "f8c6e375-362e-5223-8a59-34ff63f689eb"
 
 [compat]
-Git_jll = "2.36.1"
+Git_jll = "2.44"
 JLLWrappers = "1.1"
 julia = "1.6"
 


### PR DESCRIPTION
Bumps the Git_jll dependency to 2.44, which was [packaged]( https://github.com/JuliaPackaging/Yggdrasil/pull/8161) with more complete Windows functionality. Specifically it bundles also git bash so the git commands implemented as shell scripts work without git bash being installed externally.

Fixes #50.

I consider this as a bug fix and accordingly bumped the patch version. I'm open for other opinions.
