### PR TITLE
Add OpenSSH_jll as a direct dependency, and force our Git to use OpenSSH_jll (instead of the system `ssh`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,14 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
-      - name: On Linux only, add Github.com known hosts (from GitHub API over HTTPS)
+      - uses: dcarbone/install-jq-action@v3
+        if: runner.os == 'Linux' || runner.os == 'Windows'
+      - name: On Linux and Windows, add Github.com known hosts (from GitHub API over HTTPS)
+        shell: bash
         run: |
           mkdir -p ~/.ssh
           curl --silent https://api.github.com/meta | jq --raw-output '"github.com "+.ssh_keys[]' >> ~/.ssh/known_hosts
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' || runner.os == 'Windows'
       - uses: julia-actions/julia-runtest@v1
         env:
           CI_READONLY_DEPLOYKEY_FOR_CI_TESTSUITE_PRIVATEKEY: ${{ secrets.CI_READONLY_DEPLOYKEY_FOR_CI_TESTSUITE_PRIVATEKEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
+      - name: On Linux only, add Github.com known hosts (from GitHub API over HTTPS)
+        run: |
+          curl --silent https://api.github.com/meta | jq --raw-output '"github.com "+.ssh_keys[]' >> ~/.ssh/known_hosts
+        if: runner.os == 'Linux'
       - uses: julia-actions/julia-runtest@v1
         env:
           CI_READONLY_DEPLOYKEY_FOR_CI_TESTSUITE_PRIVATEKEY: ${{ secrets.CI_READONLY_DEPLOYKEY_FOR_CI_TESTSUITE_PRIVATEKEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - master
   push:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - name: On Linux only, add Github.com known hosts (from GitHub API over HTTPS)
         run: |
+          mkdir -p ~/.ssh
           curl --silent https://api.github.com/meta | jq --raw-output '"github.com "+.ssh_keys[]' >> ~/.ssh/known_hosts
         if: runner.os == 'Linux'
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          CI_READONLY_DEPLOYKEY_FOR_CI_TESTSUITE_PRIVATEKEY: ${{ secrets.CI_READONLY_DEPLOYKEY_FOR_CI_TESTSUITE_PRIVATEKEY }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,11 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: dcarbone/install-jq-action@v3
-        if: runner.os == 'Linux' || runner.os == 'Windows'
-      - name: On Linux and Windows, add Github.com known hosts (from GitHub API over HTTPS)
+      - name: On Linux and Windows, ssh-keyscan github.com and store in known-hosts
         shell: bash
         run: |
           mkdir -p ~/.ssh
-          curl --silent https://api.github.com/meta | jq --raw-output '"github.com "+.ssh_keys[]' >> ~/.ssh/known_hosts
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
         if: runner.os == 'Linux' || runner.os == 'Windows'
       - uses: julia-actions/julia-runtest@v1
         env:

--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,21 @@
 name = "Git"
 uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
+version = "1.4.0"
 authors = ["Dilum Aluthge", "contributors"]
-version = "1.3.1"
 
 [deps]
 Git_jll = "f8c6e375-362e-5223-8a59-34ff63f689eb"
+JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+OpenSSH_jll = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
 
 [compat]
 Git_jll = "2.44"
 JLLWrappers = "1.1"
+OpenSSH_jll = "9, 10"
 julia = "1.6"
 
 [extras]
-JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["JLLWrappers", "Test"]
+test = ["Test"]

--- a/src/git_function.jl
+++ b/src/git_function.jl
@@ -52,7 +52,7 @@ function git(; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
     end
 
     # Use OpenSSH from the JLL: <https://github.com/JuliaVersionControl/Git.jl/issues/51>.
-    if OpenSSH_jll.is_available()
+    if !Sys.iswindows() && OpenSSH_jll.is_available()
         path = split(get(ENV, "PATH", ""), pathsep)
         libpath = split(get(ENV, LIBPATH_env, ""), pathsep)
 

--- a/src/git_function.jl
+++ b/src/git_function.jl
@@ -58,6 +58,8 @@ function git(; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
 
         path = vcat(dirname(OpenSSH_jll.ssh_path), path)
         libpath = vcat(OpenSSH_jll.LIBPATH_list, libpath)
+        path = vcat(dirname(Git_jll.git_path), path)
+        libpath = vcat(Git_jll.LIBPATH_list, libpath)
 
         unique!(filter!(!isempty, path))
         unique!(filter!(!isempty, libpath))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,13 +85,11 @@ end
             end # open
             withenv("GIT_SSH_COMMAND" => "ssh -i \"$(privkey_filepath)\"") do
                 withtempdir() do workdir
-                    cd(workdir) do
-                        @test !isdir("Git.jl")
-                        @test !isfile(joinpath("Git.jl", "Project.toml"))
-                        @test success(`$(git()) clone --depth=1 git@github.com:JuliaVersionControl/Git.jl.git`)
-                        @test isdir("Git.jl")
-                        @test isfile(joinpath("Git.jl", "Project.toml"))
-                    end # cd
+                    @test !isdir("Git.jl")
+                    @test !isfile(joinpath("Git.jl", "Project.toml"))
+                    @test success(`$(git()) clone --depth=1 git@github.com:JuliaVersionControl/Git.jl.git`)
+                    @test isdir("Git.jl")
+                    @test isfile(joinpath("Git.jl", "Project.toml"))
                 end # withtempdir/workdir
             end # withenv
         end # withtempdir/sshprivkeydir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,7 @@ end
     is_ci = parse(Bool, strip(get(ENV, "CI", "false")))
     if is_ci
         @info "This is CI, so running the OpenSSH test..."
-        withtempdir() do sshprivkeydir
+        mktempdir() do sshprivkeydir
             privkey_filepath = joinpath(sshprivkeydir, "my_private_key")
             open(privkey_filepath, "w") do io
                 ssh_privkey = ENV["CI_READONLY_DEPLOYKEY_FOR_CI_TESTSUITE_PRIVATEKEY"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,7 +88,9 @@ end
                 withtempdir() do workdir
                     @test !isdir("Git.jl")
                     @test !isfile(joinpath("Git.jl", "Project.toml"))
-                    @test success(`$(git()) clone --depth=1 git@github.com:JuliaVersionControl/Git.jl.git`)
+                    # We use `run()` so that we can see the stdout and stderr in the CI logs:
+                    proc = run(`$(git()) clone --depth=1 git@github.com:JuliaVersionControl/Git.jl.git`)
+                    @test success(proc)
                     @test isdir("Git.jl")
                     @test isfile(joinpath("Git.jl", "Project.toml"))
                 end # withtempdir/workdir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,7 +73,6 @@ end
 end
 
 # https://github.com/JuliaVersionControl/Git.jl/issues/51
-
 @testset "OpenSSH integration" begin
     is_ci = parse(Bool, strip(get(ENV, "CI", "false")))
     if is_ci

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,7 +84,7 @@ end
                 ssh_privkey = ENV["CI_READONLY_DEPLOYKEY_FOR_CI_TESTSUITE_PRIVATEKEY"]
                 println(io, ssh_privkey)
             end # open
-            withenv("GIT_SSH_COMMAND" => "ssh -i \"$(privkey_filepath)\"") do
+            withenv("GIT_SSH_COMMAND" => "ssh -vvv -i \"$(privkey_filepath)\"") do
                 withtempdir() do workdir
                     @test !isdir("Git.jl")
                     @test !isfile(joinpath("Git.jl", "Project.toml"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,8 @@ end
                 ssh_privkey = ENV["CI_READONLY_DEPLOYKEY_FOR_CI_TESTSUITE_PRIVATEKEY"]
                 println(io, ssh_privkey)
             end # open
+            # We need to chmod our private key to 600, or SSH will ignore it.
+            chmod(privkey_filepath, 0o600)
             withenv("GIT_SSH_COMMAND" => "ssh -vvv -i \"$(privkey_filepath)\"") do
                 withtempdir() do workdir
                     @test !isdir("Git.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,8 +87,8 @@ end
             # We need to chmod our private key to 600, or SSH will ignore it.
             chmod(privkey_filepath, 0o600)
 
-            ssh_verbose = "-vvv" # comment this line back out when you are finished debugging
-            # ssh_verbose = "" # uncomment this line when you are finished debugging
+            # ssh_verbose = "-vvv" # comment this line back out when you are finished debugging
+            ssh_verbose = "" # uncomment this line when you are finished debugging
 
             withenv("GIT_SSH_COMMAND" => "ssh $(ssh_verbose) -i \"$(privkey_filepath)\"") do
                 withtempdir() do workdir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,7 @@ end
 @testset "OpenSSH integration" begin
     is_ci = parse(Bool, strip(get(ENV, "CI", "false")))
     if is_ci
+        @info "This is CI, so running the OpenSSH test..."
         withtempdir() do sshprivkeydir
             privkey_filepath = joinpath(sshprivkeydir, "my_private_key")
             open(privkey_filepath, "w") do io
@@ -93,5 +94,8 @@ end
                 end # withtempdir/workdir
             end # withenv
         end # withtempdir/sshprivkeydir
+    else
+        # Mark this test as skipped if we are not running in CI
+        @test_skip false
     end # if
 end # testset


### PR DESCRIPTION
Fixes #51