### PR TITLE
Support git-lfs (large file storage)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "Git"
 uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
-version = "1.4.0"
 authors = ["Dilum Aluthge", "contributors"]
+version = "1.5.0"
 
 [deps]
+Git_LFS_jll = "020c3dae-16b3-5ae5-87b3-4cb189e250b2"
 Git_jll = "f8c6e375-362e-5223-8a59-34ff63f689eb"
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 OpenSSH_jll = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
 
 [compat]
+Git_LFS_jll = "3.7"
 Git_jll = "2.44"
 JLLWrappers = "1.1"
 OpenSSH_jll = "9, 10"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ not need to have Git installed on your computer, and neither do the users of
 your packages!
 
 Git.jl provides a Git binary via
-[Git_jll.jl](https://github.com/JuliaBinaryWrappers/Git_jll.jl).
+[Git_jll.jl](https://github.com/JuliaBinaryWrappers/Git_jll.jl)
+and a Git LFS binary for large file support via
+[Git_LFS_jll.jl](https://github.com/JuliaBinaryWrappers/Git_LFS_jll.jl).
 The latest version of Git.jl requires at least Julia 1.6.
 
 Git.jl is intended to work on any platform that supports Julia,

--- a/src/git_function.jl
+++ b/src/git_function.jl
@@ -1,4 +1,5 @@
 using OpenSSH_jll: OpenSSH_jll
+using Git_LFS_jll: Git_LFS_jll
 using JLLWrappers: pathsep, LIBPATH_env
 
 """
@@ -52,8 +53,8 @@ function git(; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
     end
 
     # Use OpenSSH from the JLL: <https://github.com/JuliaVersionControl/Git.jl/issues/51>.
+    path = split(get(ENV, "PATH", ""), pathsep)
     if !Sys.iswindows() && OpenSSH_jll.is_available()
-        path = split(get(ENV, "PATH", ""), pathsep)
         libpath = split(get(ENV, LIBPATH_env, ""), pathsep)
 
         path = vcat(dirname(OpenSSH_jll.ssh_path), path)
@@ -67,6 +68,11 @@ function git(; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
         git_cmd = addenv(git_cmd, "PATH" => join(path, pathsep), LIBPATH_env => join(libpath, pathsep))
     end
 
+    # Add git-lfs
+    if Git_LFS_jll.is_available()
+        path = vcat(dirname(Git_LFS_jll.git_lfs_path), path)
+        git_cmd = addenv(git_cmd, "PATH" => join(path, pathsep))
+    end
     return git_cmd
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,20 @@ end
         @test isdir("Git.jl")
         @test isfile(joinpath("Git.jl", "Project.toml"))
     end
+
+    # git-lfs tests
+    withtempdir() do tmp_dir
+        rname = "repo-with-large-file-storage"
+        @test !isdir(rname)
+        @test !isfile(joinpath(rname, "LargeFile.zip"))
+        run(`$(git()) clone https://github.com/Apress/repo-with-large-file-storage`)
+        run(`$(git()) -C $rname lfs install --local`)
+        run(`$(git()) -C $rname lfs pull`)
+        @test isdir(rname)
+        @test isfile(joinpath(rname, "LargeFile.zip"))
+        # Test filesize to make sure we got real file and not small LFS pointer file
+        @test filesize(joinpath(rname, "LargeFile.zip")) > 10^6
+    end
 end
 
 @testset "Safety" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,9 +40,9 @@ end
         rname = "repo-with-large-file-storage"
         @test !isdir(rname)
         @test !isfile(joinpath(rname, "LargeFile.zip"))
-        run(`$(git()) clone https://github.com/Apress/repo-with-large-file-storage`)
-        run(`$(git()) -C $rname lfs install --local`)
-        run(`$(git()) -C $rname lfs pull`)
+        run(`$(git()) clone --quiet https://github.com/Apress/repo-with-large-file-storage`)
+        run(pipeline(`$(git()) -C $rname lfs install --local`; stdout=devnull))
+        run(pipeline(`$(git()) -C $rname lfs pull`; stdout=devnull))
         @test isdir(rname)
         @test isfile(joinpath(rname, "LargeFile.zip"))
         # Test filesize to make sure we got real file and not small LFS pointer file


### PR DESCRIPTION
This adds the path to the `git-lfs` binary provided by [Git_LFS_jll.jl](https://github.com/JuliaBinaryWrappers/Git_LFS_jll.jl) to the PATH in the environment of the command returned by `Git.git()`. This enables working with repositories that use the Git LFS protocol. 

I wrote a test case (which does work) but the test repo it clones is a bit big (~200 MB) so if anyone knows of / can create a smaller test repo with LFS files we can test, feel free to suggest a different one. 

With respect to the tests, I think all github runners have git-lfs installed by default and so I don't know if we should be testing something to make sure we are using the *correct* git-lfs. Anecdotally I have a mac OS laptop that does not have git-lfs installed in its global path and I can confirm that this works on that machine.

Thanks to @giordano for providing advice on how to get started with this implementation. 