### PR TITLE
Require at least Julia 1.6.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ OpenSSH_jll = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
 Git_jll = "2.44"
 JLLWrappers = "1.1"
 OpenSSH_jll = "9, 10"
-julia = "1.6"
+julia = "1.6.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This is the first Julia version that can handle nested `addenv` calls on Windows (for #64).

X-ref: https://github.com/JuliaVersionControl/Git.jl/pull/64#issuecomment-3104376050